### PR TITLE
Update Si.md

### DIFF
--- a/content/docs/Getting Started/Si.md
+++ b/content/docs/Getting Started/Si.md
@@ -9,7 +9,7 @@ next: "/docs/components"
 ---
 
 
-Here we provide a simple example on how to run `Green`/`Weakcoupling` on the example of a periodic silicon on `6x6x6` lattice. Prerequisites: you must have both the mbpt and the ac executables compiled. Change to a new directory where you will keep your simulations, create a directory for the Si simulation, and create the file `a.dat` containing the following unit cell information:
+Here we provide a simple example on how to run `Green`/`Weakcoupling` on the example of a periodic silicon on `6x6x6` lattice. Prerequisites: you must have both the mbpt and the ac executables compiled, and the ![green-mbtools](https://github.com/green-phys/green-mbtools) python package installed. Change to a new directory where you will keep your simulations, create a directory for the Si simulation, and create the file `a.dat` containing the following unit cell information:
 ```
 0.0,  2.7155, 2.7155
 2.7155, 0.0,  2.7155
@@ -27,12 +27,17 @@ We then obtain input parameters and the initial mean-field solution by running p
 ```
 python <source root>/green-mbpt/python/init_data_df.py        \
   --a a.dat --atom atom.dat --nk 6                            \
-  --basis gth-dzvp-molopt-sr --pseudo gth-pbe --xc PBE        \
-  --high_symmetry_path WGXWLG  --high_symmetry_path_points 100
+  --basis gth-dzvp-molopt-sr --pseudo gth-pbe --xc PBE
 ```
-Here we use the `gth-dzvp-molopt-sr` basis with the `gth-pbe` psudopotential and run `DFT` mean-field approximation  with a `PBE` exchange correlation potential,
-we set high-symmetry path to `WGXWLG` to reproduce results from [Phys. Rev. B 106, 235104].
+Here we use the `gth-dzvp-molopt-sr` basis with the `gth-pbe` psudopotential and run `DFT` mean-field approximation  with a `PBE` exchange correlation potential.
 
+The primary goal of this example is to generate the band structure of Silicon. For that, we also require the overlap matrix and one-electron Hamiltonian along the high-symmetry path. To reproduce the results from [Phys. Rev. B 106, 235104], we set high-symmetry path to `WGXWLG` to reproduce results from [Phys. Rev. B 106, 235104]. This is also obtained via the `init_data_df.py` script, but with an additional `--job sym_path` flag:
+```
+python <source root>/green-mbpt/python/init_data_df.py        \
+  --a a.dat --atom atom.dat --nk 6                            \
+  --basis gth-dzvp-molopt-sr --pseudo gth-pbe --xc PBE        \
+  --job sym_path --high_symmetry_path WGXWLG  --high_symmetry_path_points 100
+```
 
 After that we will run the `GW` approximation
 

--- a/content/docs/Getting Started/preparing_input.md
+++ b/content/docs/Getting Started/preparing_input.md
@@ -29,10 +29,11 @@ which contain the Coloumb and one-body integrals of the system.
 
 ### High-symmetry path
 
-After the simulation is performed, results (such as band structures) could be displayed along a high-symmetry path. To obtain a specific high-symmetry path,
-specify the high-symmetry points on the path and the total number of points along the path by providing the two parameters `--high_symmetry_path` and `--high_symmetry_path_points`.
+After the simulation is performed, results (such as band structures) could be displayed along a high-symmetry path.
+Before performing Green's function calculations, it helps to prepare the overlap matrix and one-electron integrals along this path in the Brillouin zone.
+To obtain these quantities, we use `init_data_df.py` once again, but with the flag `--job sym_path`.
+In addition to this option, one needs to specify the high-symmetry points on the path and the total number of points along the path by providing the two parameters `--high_symmetry_path` and `--high_symmetry_path_points`.
 To see all available high-symmetry points for a chosen system, use theoption `--print_high_symmetry_points`.
-The interplation along high-symmetry paths will perform a basic Wannier interpolation.
 
 ## Coulomb integrals generation
 

--- a/content/docs/Getting Started/running_greens.md
+++ b/content/docs/Getting Started/running_greens.md
@@ -24,6 +24,6 @@ To get information about other parameters and their default values call `mbpt.ex
 ### Band-path interpolation
 
 If input data contains information about high-symmetry path,
-diagonal part of the Green's function can be evaluated on provided high-symmetry path, and results will be stored in the `G_tau_hs` group in `--high_symmetry_output_file`.
+diagonal part of the Green's function can be evaluated on provided high-symmetry path using Wannier interpolation, and results will be stored in the `G_tau_hs` group in `--high_symmetry_output_file`.
 (by default set to `output_hs.h5`).
-For that the option `--jobs WINTER`
+For that the option `--jobs WINTER`.


### PR DESCRIPTION
Updating example to keep updated with recent changes in python scripts. In its original form, the "high_symmetry_path" data group will not be generated by the python script. We need to add the "--job sym_path" argument and run the input script again to get these data entries.