### PR TITLE
docs: explain CMake dependency prefixes

### DIFF
--- a/content/docs/installation/from_sources.md
+++ b/content/docs/installation/from_sources.md
@@ -53,8 +53,20 @@ The following instructions will download and build the CPU-only version of the M
   $ cmake --build green-mbpt-build -t test
   ```
 
-If you have a non-standard installation location of the dependent packages installed in step 1, cmake will fail to find the package. Green uses the standard cmake mechanism (FindXXX.cmake) to find packages. The following pointers may help:
-  - For Eigen: specify in the cmake line: -DEigen3_DIR=/header/directory/of/eigen
+If dependencies are installed under a non-default prefix, add that prefix to
+the configure command. For an active Conda environment, for example:
+
+  ```ShellSession
+  $ cmake -S green-mbpt -B green-mbpt-build               \
+       -DCMAKE_INSTALL_PREFIX=/path/to/install/directory  \
+       -DCMAKE_PREFIX_PATH="$CONDA_PREFIX"                 \
+       -DCMAKE_BUILD_TYPE=Release
+  ```
+
+`CMAKE_PREFIX_PATH` gives CMake one common search root for packages including
+MPI, HDF5, BLAS, and Eigen. Separate multiple prefixes with semicolons. For a
+package-specific override, the following pointers may help:
+  - For Eigen: specify `-DEigen3_DIR=/path/to/lib/cmake/eigen3`, pointing to the directory that contains `Eigen3Config.cmake`
   - For MPI: Follow the instructions on [cmake with mpi](https://cmake.org/cmake/help/latest/module/FindMPI.html)
   - For BLAS: Follow the instructions on [cmake with BLAS](https://cmake.org/cmake/help/latest/module/FindBLAS.html)
   - For HDF5: Follow the instructions on [cmake with HDF5](https://cmake.org/cmake/help/latest/module/FindHDF5.html)
@@ -134,8 +146,12 @@ The following instructions will download and build the Analytical Continuation p
   $ cmake --build green-ac-build -t test install
 ```
 
-If you have a non-standard installation location of the dependent packages installed in step 1, cmake will fail to find the package. Green uses the standard cmake mechanism (FindXXX.cmake) to find packages. The following pointers may help:
-  - For Eigen: specify in the cmake line: -DEigen3_DIR=/header/directory/of/eigen
+If dependencies are installed under a non-default prefix, pass it during
+configuration, for example `-DCMAKE_PREFIX_PATH="$CONDA_PREFIX"` for an active
+Conda environment. This gives CMake one common search root for MPI, HDF5, BLAS,
+Eigen, and GMP. For a package-specific override, the following pointers may
+help:
+  - For Eigen: specify `-DEigen3_DIR=/path/to/lib/cmake/eigen3`, pointing to the directory that contains `Eigen3Config.cmake`
   - For MPI: Follow the instructions on [cmake with mpi](https://cmake.org/cmake/help/latest/module/FindMPI.html)
   - For BLAS: Follow the instructions on [cmake with BLAS](https://cmake.org/cmake/help/latest/module/FindBLAS.html)
   - For HDF5: Follow the instructions on [cmake with HDF5](https://cmake.org/cmake/help/latest/module/FindHDF5.html)


### PR DESCRIPTION
## Summary

- add a complete Conda-based `CMAKE_PREFIX_PATH` configure example
- explain how one prefix helps CMake discover MPI, HDF5, BLAS, Eigen, and GMP
- document semicolon-separated multiple prefixes
- correct `Eigen3_DIR` to point at the directory containing `Eigen3Config.cmake`, not an Eigen header directory

## Feedback validation

Valid. The existing page only links to individual Find modules and its Eigen-specific fallback points to the wrong directory type.

## Test plan

- `git diff --check`
- `hugo --gc --minify` reaches rendering but the existing site fails under local Hugo 0.162 at `layouts/partials/sidebar.html:46` because `site.IsMultiLingual` is unavailable