### PR TITLE
Green button theme + two-tier homepage hierarchy

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -5,14 +5,14 @@
   --navbar-height: 4rem;
   --menu-height: 3.75rem;
   --button-width: 210px;
-  --btn-hue: 42deg;
-  --btn-saturation: 50%;
+  /* Buttons track the site's green primary (in both light and dark modes). */
+  --btn-hue: var(--primary-hue);
+  --btn-saturation: var(--primary-saturation);
 }
 
 .dark {
   --primary-hue: 102deg;
   --primary-saturation: 100%;
-  --btn-saturation: 100%;
 }
 
 .home-flex {
@@ -64,14 +64,14 @@
 }
 
 .btn-primary {
-  background-color: hsl(var(--btn-hue) var(--btn-saturation) 35%);
-  border: 2px solid hsl(var(--btn-hue) var(--btn-saturation) 35%);
+  background-color: hsl(var(--btn-hue) var(--btn-saturation) 30%);
+  border: 2px solid hsl(var(--btn-hue) var(--btn-saturation) 30%);
   color: #f7f7f7 !important;
 }
 
 .btn-primary:hover {
-  background-color: hsl(var(--btn-hue) var(--btn-saturation) 28%);
-  border-color: hsl(var(--btn-hue) var(--btn-saturation) 28%);
+  background-color: hsl(var(--btn-hue) var(--btn-saturation) 24%);
+  border-color: hsl(var(--btn-hue) var(--btn-saturation) 24%);
   color: #ffffff !important;
 }
 
@@ -178,6 +178,26 @@
 .btn-grid-4 .btn {
   width: 100%;
   margin: 0;
+}
+
+/* Secondary tier: small, wrapping pill buttons below the hero row. */
+.btn-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 1rem 0 1.5rem;
+}
+
+.btn-sm {
+  width: auto;
+  padding: 0.3rem 0.7rem;
+  font-size: 0.8rem;
+  border-width: 1px;
+  margin: 0;
+}
+
+.btn-sm .material-icons {
+  font-size: 1rem;
 }
 
 .news {

--- a/content/_index.md
+++ b/content/_index.md
@@ -19,50 +19,31 @@ Green is a software framework for the simulation of realistic materials with Gre
 </div>
 
 <br>
-<div class="btn-grid">
-{{< cta-button text="Installation" link="docs/installation/" icon="rocket_launch" >}}
+<div class="btn-grid-4">
+{{< cta-button text="Installation" link="docs/installation/" icon="rocket_launch" prim="yes" >}}
 {{< cta-button text="Getting Started" link="docs/getting-started/" icon="school" >}}
 {{< cta-button text="Documentation" link="docs/" icon="book" >}}
-{{< cta-button text="GitHub Source" link="https://github.com/Green-Phys" icon="code" >}}
-{{< cta-button text="Submit an issue" link="https://green-phys.youtrack.cloud/newIssue?project=GEF&summary=New+Bug+Template&description=**Describe+the+bug**%0AA+clear+and+concise+description+of+what+the+bug+is.%0A%0A**Expected+behavior**%0AA+clear+and+concise+description+of+what+you+expected+to+happen.%0A%0A**Reproduction+steps**%0ASteps+to+reproduce+the+bug.%0A%3C%21--+Usually+this+means+a+small+and+self-contained+piece+of+code+that+uses+Catch+and+specifying+compiler+flags+if+relevant.+--%3E%0A%0A**Logfile**%0AIf+applicable%2C+add+log-files+to+help+explain+your+problem.%0A%0A**Platform+%28please+complete+the+following+information%29%3A**%0A+-+OS%3A+%5Be.g.+Linux+Ubuntu+20.004%5D%0A+-+Compiler+version%3A+%5Be.g.+gcc+12.2%2C+clang+15.0...%5D%0A+-+If+applicable%2C+super-computing+facility+where+bug+happened+%5Be.g.+DOE+NERSC%2C+SDSC+Expanse...%5D%0A%0A%0A**Additional+context**%0AAdd+any+other+context+about+the+problem+here.%0A&c=add+Board+GEF+Project+Development+Unscheduled&c=Type+Bug&c=State+Open" icon="error" >}}
-{{< cta-button text="Discord" link="https://discord.gg/ty9FE6u3mg" icon="forum" >}}
-{{< cta-button text="Troubleshooting" link="/docs/troubleshoot/" icon="troubleshoot" >}}
-{{< cta-button text="Papers and Citations" link="/docs/publications/" icon="library_books" >}}
-{{< cta-button text="Cite" link="/data/iskakov2025.bib" icon="format_quote" >}}
+{{< cta-button text="Submit an issue" link="https://green-phys.youtrack.cloud/newIssue?project=GEF&summary=New+Bug+Template&description=**Describe+the+bug**%0AA+clear+and+concise+description+of+what+the+bug+is.%0A%0A**Expected+behavior**%0AA+clear+and+concise+description+of+what+you+expected+to+happen.%0A%0A**Reproduction+steps**%0ASteps+to+reproduce+the+bug.%0A%3C%21--+Usually+this+means+a+small+and+self-contained+piece+of+code+that+uses+Catch+and+specifying+compiler+flags+if+relevant.+--%3E%0A%0A**Logfile**%0AIf+applicable%2C+add+log-files+to+help+explain+your+problem.%0A%0A**Platform+%28please+complete+the+following+information%29%3A**%0A+-+OS%3A+%5Be.g.+Linux+Ubuntu+20.004%5D%0A+-+Compiler+version%3A+%5Be.g.+gcc+12.2%2C+clang+15.0...%5D%0A+-+If+applicable%2C+super-computing+facility+where+bug+happened+%5Be.g.+DOE+NERSC%2C+SDSC+Expanse...%5D%0A%0A%0A**Additional+context**%0AAdd+any+other+context+about+the+problem+here.%0A&c=add+Board+GEF+Project+Development+Unscheduled&c=Type+Bug&c=State+Open" icon="error" err="yes" >}}
 </div>
 
-## Theory
-<br>
-
-<div class="btn-grid">
-{{< cta-button text="Introduction" link="/docs/theory/introduction/" icon="info" >}}
-{{< cta-button text="GF2" link="/docs/theory/gf2_theory/" icon="functions" >}}
-{{< cta-button text="GW" link="/docs/theory/gw_theory/" icon="science" >}}
-{{< cta-button text="Post-processing" link="/docs/theory/postprocessing/" icon="analytics" >}}
-{{< cta-button text="Convergence" link="/docs/theory/convergence_acceleration/" icon="trending_down" >}}
-</div>
-
-## Tutorials
-<br>
-
-<div class="btn-grid">
-{{< cta-button text="Input preparation" link="/docs/getting-started/preparing_input/" icon="input" >}}
-{{< cta-button text="Weak-coupling code" link="/docs/getting-started/running_greens/" icon="terminal" >}}
-{{< cta-button text="Post-processing" link="/docs/getting-started/postprocessing/" icon="analytics" >}}
-{{< cta-button text="Examples" link="/docs/getting-started/examples/si/" icon="code" >}}
-{{< cta-button text="Lattice Parameters" link="/docs/tutorials/lattice/" icon="grid_view" >}}
-{{< cta-button text="Convergence Acceleration" link="/docs/tutorials/diis/" icon="speed" >}}
-{{< cta-button text="MBAnalysis" link="/docs/tutorials/mbanalysis/" icon="insights" >}}
+<div class="btn-row">
+{{< cta-button text="Theory" link="/docs/theory/" icon="menu_book" sm="yes" >}}
+{{< cta-button text="Tutorials" link="/docs/tutorials/" icon="insights" sm="yes" >}}
+{{< cta-button text="Examples" link="/docs/getting-started/examples/si/" icon="terminal" sm="yes" >}}
+{{< cta-button text="Green-MBTools" link="https://green-phys.org/green-mbtools" icon="extension" sm="yes" >}}
+{{< cta-button text="GitHub" link="https://github.com/Green-Phys" icon="code" sm="yes" >}}
+{{< cta-button text="Discord" link="https://discord.gg/ty9FE6u3mg" icon="forum" sm="yes" >}}
+{{< cta-button text="Troubleshooting" link="/docs/troubleshoot/" icon="troubleshoot" sm="yes" >}}
+{{< cta-button text="Papers and Citations" link="/docs/publications/" icon="library_books" sm="yes" >}}
+{{< cta-button text="Cite" link="/data/iskakov2025.bib" icon="format_quote" sm="yes" >}}
 </div>
 
 ## Acknowledgement
 
-This material is based upon work supported by the National Science Foundation (NSF) CSSI program under award No. OAC-2310582.
-
 <div style="display:flex; align-items:center; gap:1.5rem; margin-top:1rem; flex-wrap:wrap;">
 <a href="https://www.nsf.gov" target="_blank"><img src="/logo/NSF.webp" alt="NSF" style="height:80px;" /></a>
-<div>
-Supported by the US National Science Foundation under award
-<a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=2310582" target="_blank">NSF OAC-2310582</a>.
+<div style="flex:1 1 320px;">
+This material is based upon work supported by the National Science Foundation (NSF) CSSI program under<br>
+award No. <a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=2310582" target="_blank">OAC-2310582</a>.
 </div>
 </div>

--- a/layouts/shortcodes/cta-button.html
+++ b/layouts/shortcodes/cta-button.html
@@ -3,11 +3,12 @@
 {{- $text := .Get "text" -}}
 {{- $prim := .Get "prim" -}}
 {{- $error := .Get "err" -}}
+{{- $sm := .Get "sm" -}}
 
 {{- $external := hasPrefix $link "http" -}}
 {{- $href := cond (hasPrefix $link "/") ($link | relURL) $link -}}
 
-<a href="{{- $href -}}" class="btn {{ if $prim }}btn-primary{{ else if $error }}btn-outlined-error{{ else }}btn-outlined-primary{{ end }}"
+<a href="{{- $href -}}" class="btn {{ if $prim }}btn-primary{{ else if $error }}btn-outlined-error{{ else }}btn-outlined-primary{{ end }}{{ if $sm }} btn-sm{{ end }}"
   {{ if $external }}target="_blank" rel="noreferrer"{{ end -}}>
   <span class="material-icons">{{ $icon }}</span>
   {{ with $text }}{{ . }}{{ end }}


### PR DESCRIPTION
Meets egull's modernized homepage in the middle: keeps the intro + Rosetta
diagram layout, but reworks the button treatment.

## Changes
- **Green buttons.** Retarget `--btn-hue`/`--btn-saturation` from the amber
  42deg to the site's green primary (aliased, so they track links/headings in
  light and dark modes). Filled primary button darkened slightly to clear
  WCAG AA contrast.
- **Two-tier hierarchy.** Homepage goes from ~21 flat, equally-weighted buttons
  to **4 hero buttons** (Installation, Getting Started, Documentation, Submit an
  issue) plus a wrapping row of **small secondary pills**.
- **Collapse Theory/Tutorials.** The two homepage sections (12 subsection
  buttons) become single `Theory` and `Tutorials` pills; sub-navigation lives in
  the sidebar.
- **Extra pills.** Added `Examples` (Si walkthrough) and `Green-MBTools`
  (→ green-phys.org/green-mbtools, the package's own docs site).
- **NSF acknowledgement.** Deduplicated into one statement beside the logo and
  fixed its wrapping.

## Files
- `assets/css/custom.css` — button color vars + `.btn-row`/`.btn-sm` styles
- `content/_index.md` — two-tier restructure
- `layouts/shortcodes/cta-button.html` — new `sm` param

🤖 Generated with [Claude Code](https://claude.com/claude-code)