### PR TITLE
Cite the published Green paper on the Acknowledgment page

### DIFF
--- a/content/docs/acknowledgment.md
+++ b/content/docs/acknowledgment.md
@@ -9,10 +9,15 @@ Green Framework is published under the [MIT License](https://opensource.org/lice
 ### Citations
 
 While the license allows to use, modify and distribute the code without any restriction, we kindly request 
-that projects using parts of the Green Framework include a citation to the following DOI:
+that projects using parts of the Green Framework include a citation to the following paper:
 
-   - [10.5281/zenodo.10071545](https://zenodo.org/doi/10.5281/zenodo.10071545)
+Sergei Iskakov, Chia-Nan Yeh, Pavel Pokhilko, Yang Yu, Lei Zhang, Gaurav Harsha, Vibin Abraham, Ming Wen, Munkhorgil Wang, Jacob Adamski, Tianran Chen, Emanuel Gull, Dominika Zgid, *"Green/WeakCoupling: Implementation of fully self-consistent finite-temperature many-body perturbation theory for molecules and solids"*, Computer Physics Communications, 306, 109380 (2025).
 
-A paper on the Green framework will be submitted shortly.
+<div class="btn-grid">
+{{< cta-button text="Citation" link="https://doi.org/10.1016/j.cpc.2024.109380" icon="format_quote" >}}
+{{< cta-button text="BibTeX" link="/data/iskakov2025.bib" icon="format_quote" >}}
+</div>
+
+See the [Papers and Citations](/docs/publications/) page for additional references.
 
 In addition, users are asked to cite the original scientific literature for the theories and algorithms used.


### PR DESCRIPTION
## Summary
- Update the Acknowledgment page to ask users to cite the published Green paper (Iskakov et al. 2025, *Computer Physics Communications*) instead of the Zenodo pre-publication DOI
- Add Citation and BibTeX buttons matching the homepage's button style, and link to the full Papers and Citations page

## Test plan
- [ ] Visually check `/docs/acknowledgment/` renders the citation text and buttons correctly

https://claude.ai/code/session_019Zb1idPGYpX5dr6aKySHMC
