### PR TITLE
Revise Developers page: PI titles, profile links, combined contributors

### DIFF
--- a/content/docs/developers.md
+++ b/content/docs/developers.md
@@ -19,28 +19,28 @@ prev: "/docs/troubleshoot"
 
 ## Current and Former Contributors
 
-{{<person name="Vibin Abraham" head="/headshots/avibin.jpg" />}}
+{{<person name="Vibin Abraham" head="/headshots/avibin.jpg" link="https://scholar.google.com/citations?hl=en&user=86sYnsYAAAAJ" />}}
 
 {{<person name="Jacob Adamski" head="/headshots/adamskij.jpg" />}}
 
-{{<person name="Tianran Chen" head="/headshots/tchen.jpg" />}}
+{{<person name="Tianran Chen" head="/headshots/tchen.jpg" link="https://www.wcupa.edu/_admin/research/forms/ram-research-directory/profile.aspx?id=104" />}}
 
-{{< person name="Sergei Iskakov" contact="siskakov@umich.edu" head="/headshots/siskakov.jpg" />}}
+{{< person name="Sergei Iskakov" contact="siskakov@umich.edu" head="/headshots/siskakov.jpg" link="https://scholar.google.com/citations?user=NZ93EwYAAAAJ" />}}
 
-{{<person name="Agnieszka Jażdżewska"/>}}
+{{<person name="Agnieszka Jażdżewska" link="https://m.fuw.edu.pl/phd-students.html?show=481931" />}}
 
-{{<person name="Jia Li" head="/headshots/jli.jpg" />}}
+{{<person name="Jia Li" head="/headshots/jli.jpg" link="https://scholar.google.com/citations?hl=en&user=E6h8_CEAAAAJ" />}}
 
-{{<person name="Pavel Pokhilko" head="/headshots/pokhilko.jpg" />}}
+{{<person name="Pavel Pokhilko" head="/headshots/pokhilko.jpg" link="https://scholar.google.com/citations?hl=en&user=7yROcoIAAAAJ" />}}
 
-{{<person name="Munkhorgil Wang" head="/headshots/munkhw.jpg"/>}}
+{{<person name="Munkhorgil Wang" head="/headshots/munkhw.jpg" link="https://scholar.google.com/citations?hl=en&user=ndw73lcAAAAJ" />}}
 
-{{<person name="Ming Wen" />}}
+{{<person name="Ming Wen" link="https://scholar.google.com/citations?hl=en&user=t7HA5-sAAAAJ" />}}
 
-{{<person name="Chia-Nan Yeh"  head="/headshots/cnyeh.jpg" />}}
+{{<person name="Chia-Nan Yeh"  head="/headshots/cnyeh.jpg" link="https://www.simonsfoundation.org/people/chia-nan-yeh/" />}}
 
 {{<person name="Runxue Yu" head="/headshots/runxueyu.jpg" />}}
 
-{{<person name="Yang Yu" head="/headshots/umyangyu.jpg" />}}
+{{<person name="Yang Yu" head="/headshots/umyangyu.jpg" link="https://scholar.google.com/citations?user=fjJ3INIAAAAJ" />}}
 
-{{<person name="Lei Zhang" head="/headshots/lzphy.jpg" />}}
+{{<person name="Lei Zhang" head="/headshots/lzphy.jpg" link="https://scholar.google.com/citations?user=znwC5ycAAAAJ" />}}

--- a/content/docs/developers.md
+++ b/content/docs/developers.md
@@ -7,17 +7,17 @@ prev: "/docs/troubleshoot"
 ---
 
 
-## Primary Investigators
+## Principal Investigators
 
-{{<person name="Emanuel Gull" contact="egull@umich.edu" title="" head="/headshots/egull.jpg" />}}
+{{<person name="Emanuel Gull" contact="egull@umich.edu" title="" head="/headshots/egull.jpg" link="https://gull-group.org" />}}
 
-{{<person name="Dominika Zgid" contact="zgid@umich.edu" title="" head="/headshots/zgid.jpg" />}}
+{{<person name="Dominika Zgid" contact="zgid@umich.edu" title="" head="/headshots/zgid.jpg" link="https://sites.lsa.umich.edu/zgid/" />}}
 
 ## Lead Developer
 
-{{<person name="Gaurav Harsha" head="/headshots/gaurav.jpg" />}}
+{{<person name="Gaurav Harsha" head="/headshots/gaurav.jpg" link="https://gauravharsha.github.io/" />}}
 
-## Team Members
+## Current and Former Contributors
 
 {{<person name="Vibin Abraham" head="/headshots/avibin.jpg" />}}
 
@@ -37,16 +37,10 @@ prev: "/docs/troubleshoot"
 
 {{<person name="Agnieszka Jażdżewska"/>}}
 
-## Contributors
-
 {{<person name="Jia Li" head="/headshots/jli.jpg" />}}
 
 {{<person name="Chia-Nan Yeh"  head="/headshots/cnyeh.jpg" />}}
 
-## Retired Team Members
-
 {{< person name="Sergei Iskakov" contact="siskakov@umich.edu" head="/headshots/siskakov.jpg" />}}
-
-
 
 {{<person name="Runxue Yu" head="/headshots/runxueyu.jpg" />}}

--- a/content/docs/developers.md
+++ b/content/docs/developers.md
@@ -25,22 +25,22 @@ prev: "/docs/troubleshoot"
 
 {{<person name="Tianran Chen" head="/headshots/tchen.jpg" />}}
 
+{{< person name="Sergei Iskakov" contact="siskakov@umich.edu" head="/headshots/siskakov.jpg" />}}
+
+{{<person name="Agnieszka Jażdżewska"/>}}
+
+{{<person name="Jia Li" head="/headshots/jli.jpg" />}}
+
 {{<person name="Pavel Pokhilko" head="/headshots/pokhilko.jpg" />}}
 
 {{<person name="Munkhorgil Wang" head="/headshots/munkhw.jpg"/>}}
 
 {{<person name="Ming Wen" />}}
 
+{{<person name="Chia-Nan Yeh"  head="/headshots/cnyeh.jpg" />}}
+
+{{<person name="Runxue Yu" head="/headshots/runxueyu.jpg" />}}
+
 {{<person name="Yang Yu" head="/headshots/umyangyu.jpg" />}}
 
 {{<person name="Lei Zhang" head="/headshots/lzphy.jpg" />}}
-
-{{<person name="Agnieszka Jażdżewska"/>}}
-
-{{<person name="Jia Li" head="/headshots/jli.jpg" />}}
-
-{{<person name="Chia-Nan Yeh"  head="/headshots/cnyeh.jpg" />}}
-
-{{< person name="Sergei Iskakov" contact="siskakov@umich.edu" head="/headshots/siskakov.jpg" />}}
-
-{{<person name="Runxue Yu" head="/headshots/runxueyu.jpg" />}}

--- a/layouts/shortcodes/person.html
+++ b/layouts/shortcodes/person.html
@@ -2,11 +2,12 @@
 {{- $name := .Get "name" }}
 {{- $title := .Get "title" }}
 {{- $head := .Get "head" }}
+{{- $link := .Get "link" }}
 
 
 <div class="gdoc-columns gdoc-columns--regular hx:flex flex-gap flex-mobile-column">
 <div style="display: inline-block; width:600px">
-<h3>{{- $name }}</h3>
+<h3>{{- if $link }}<a href="{{ $link }}" target="_blank" rel="noopener">{{- $name }}</a>{{- else }}{{- $name }}{{- end }}</h3>
 
 {{- if $title }}
 <h3>{{- $title }}</h3>


### PR DESCRIPTION
## Summary
- Rename "Primary Investigators" to "Principal Investigators" on the Developers page
- Link Emanuel Gull, Dominika Zgid, and Gaurav Harsha to their personal/group pages
- Merge Team Members, Contributors, and Retired Team Members into a single "Current and Former Contributors" section, sorted alphabetically by last name
- Add homepage or Google Scholar links for each contributor where one could be confidently found (homepage preferred over Scholar; left empty if neither exists)
- Add `link` support to the `person` shortcode so names render as hyperlinks

## Test plan
- [ ] Visually check `/docs/developers/` renders headings, links, and contributor order correctly

https://claude.ai/code/session_019Zb1idPGYpX5dr6aKySHMC
