### PR TITLE
Point "Submit an issue" at green-mbpt GitHub issues

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -23,7 +23,7 @@ Green is a software framework for the simulation of realistic materials with Gre
 {{< cta-button text="Installation" link="docs/installation/" icon="rocket_launch" prim="yes" >}}
 {{< cta-button text="Getting Started" link="docs/getting-started/" icon="school" >}}
 {{< cta-button text="Documentation" link="docs/" icon="book" >}}
-{{< cta-button text="Submit an issue" link="https://green-phys.youtrack.cloud/newIssue?project=GEF&summary=New+Bug+Template&description=**Describe+the+bug**%0AA+clear+and+concise+description+of+what+the+bug+is.%0A%0A**Expected+behavior**%0AA+clear+and+concise+description+of+what+you+expected+to+happen.%0A%0A**Reproduction+steps**%0ASteps+to+reproduce+the+bug.%0A%3C%21--+Usually+this+means+a+small+and+self-contained+piece+of+code+that+uses+Catch+and+specifying+compiler+flags+if+relevant.+--%3E%0A%0A**Logfile**%0AIf+applicable%2C+add+log-files+to+help+explain+your+problem.%0A%0A**Platform+%28please+complete+the+following+information%29%3A**%0A+-+OS%3A+%5Be.g.+Linux+Ubuntu+20.004%5D%0A+-+Compiler+version%3A+%5Be.g.+gcc+12.2%2C+clang+15.0...%5D%0A+-+If+applicable%2C+super-computing+facility+where+bug+happened+%5Be.g.+DOE+NERSC%2C+SDSC+Expanse...%5D%0A%0A%0A**Additional+context**%0AAdd+any+other+context+about+the+problem+here.%0A&c=add+Board+GEF+Project+Development+Unscheduled&c=Type+Bug&c=State+Open" icon="error" err="yes" >}}
+{{< cta-button text="Submit an issue" link="https://github.com/Green-Phys/green-mbpt/issues/new/choose" icon="error" err="yes" >}}
 </div>
 
 <div class="btn-row">


### PR DESCRIPTION
Migrates the homepage "Submit an issue" button off YouTrack and onto GitHub, matching the move of issue tracking into the `Green-Phys` org.

## Change
- `content/_index.md`: the "Submit an issue" button now links to
  `https://github.com/Green-Phys/green-mbpt/issues/new/choose` — the template
  chooser (same as clicking **New Issue**), so users pick Bug report vs Feature
  request themselves.

## Notes
- Filing an issue now requires a (free) GitHub account; the Discord pill remains as a no-login channel.
- Independent of the site-modernization work — based directly on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)