### PR TITLE
Clarify analytical continuation docs cover Nevanlinna/Caratheodory, link MiniPole

### DIFF
--- a/content/docs/installation/general_ac.md
+++ b/content/docs/installation/general_ac.md
@@ -6,6 +6,8 @@ weight: 2
 
 ### Analytical continuation package
 
+This page covers installation of the Nevanlinna and Caratheodory analytical continuation methods. For the MiniPole continuation code, see the [MiniPole repository](https://github.com/Green-Phys/MiniPole) for installation instructions.
+
 {{% steps %}}
 
 ### Prerequisites: HPC libraries and tools


### PR DESCRIPTION
## Summary
- The Analytical Continuation installation page now states it covers the Nevanlinna and Caratheodory methods
- Links to the [MiniPole repository](https://github.com/Green-Phys/MiniPole) for installation instructions for the MiniPole continuation code

## Test plan
- [ ] Render the docs site locally and confirm the new note appears correctly at `/docs/installation/general_ac/`