### PR TITLE
Replace stale YouTrack issue links with GitHub issues link

### DIFF
--- a/content/docs/contribution.md
+++ b/content/docs/contribution.md
@@ -7,7 +7,7 @@ icon: thumb-up
 Contribution to any part of the Green project is open for every user.
 
 There are three options to contribute
-  - [Submit an issue](#submit-an-issue) on [issue tracker](https://green-phys.youtrack.cloud/newIssue)
+  - [Submit an issue](#submit-an-issue) on [issue tracker](https://github.com/Green-Phys/green-mbpt/issues/new/choose)
   - [Propose changes](#contributing-to-green) in the code via pull-request (PR)
   - [Writing Documentation](#writing-documentation)
 
@@ -15,7 +15,7 @@ There are three options to contribute
 ## Submit an issue
 
 If you found a bug or want new feature to be implemented, Green project 
-has an [issue tracking](https://green-phys.youtrack.cloud/newIssue) website where you can submit related information. Please try to 
+has an [issue tracking](https://github.com/Green-Phys/green-mbpt/issues/new/choose) website where you can submit related information. Please try to 
 put a detailed and reproducible description.
 
 

--- a/content/docs/installation/_index.md
+++ b/content/docs/installation/_index.md
@@ -15,7 +15,7 @@ Green is currently installed by building from source. Choose the guide that matc
 
 **Users on DOE systems** (e.g. NERSC Perlmutter) should follow the DOE machine guide for the same reason.
 
-If your system isn't covered here and you run into trouble, please file an [issue](https://green-phys.youtrack.cloud/newIssue) — we're glad to help, and to add new machine-specific guides as they're worked out.
+If your system isn't covered here and you run into trouble, please file an [issue](https://github.com/Green-Phys/green-mbpt/issues/new/choose) — we're glad to help, and to add new machine-specific guides as they're worked out.
 
 <div class="btn-grid">
 {{< cta-button text="General Installation" link="from_sources" icon="rocket_launch" >}}

--- a/content/docs/installation/from_sources.md
+++ b/content/docs/installation/from_sources.md
@@ -175,9 +175,9 @@ The code has been successfully built and tested on National HPC resources. Instr
   - [DOE Machines](/docs/installation/doe/)
     - [NERSC Perlmutter](/docs/installation/doe/perlmutter)
 
-If you would like to have the code tested on additional machines please let us know by filing an [issue](https://green-phys.youtrack.cloud/newIssue).
+If you would like to have the code tested on additional machines please let us know by filing an [issue](https://github.com/Green-Phys/green-mbpt/issues/new/choose).
 
 ### Installation issues
-   If you encounter issues with compiling, installing, or testing the package please file an issue on our github issues [page](https://green-phys.youtrack.cloud/newIssue), and we will do our best to help.
+   If you encounter issues with compiling, installing, or testing the package please file an issue on our github issues [page](https://github.com/Green-Phys/green-mbpt/issues/new/choose), and we will do our best to help.
 
 

--- a/content/docs/installation/general_ac.md
+++ b/content/docs/installation/general_ac.md
@@ -47,5 +47,5 @@ help:
 
 
 ### Installation issues
-   If you encounter issues with compiling, installing, or testing the package please file an issue on our issues server [page](https://green-phys.youtrack.cloud/newIssue), and we will do our best to help.
+   If you encounter issues with compiling, installing, or testing the package please file an issue on our issues server [page](https://github.com/Green-Phys/green-mbpt/issues/new/choose), and we will do our best to help.
    Help is also available on our [discord server](https://discord.gg/ty9FE6u3mg).

--- a/content/docs/troubleshoot.md
+++ b/content/docs/troubleshoot.md
@@ -10,7 +10,7 @@ prev: "/docs/tutorials"
 If you run into an issue that isn't covered below, please file an issue or reach us on Discord — we will do our best to help.
 
 <div class="btn-grid">
-{{< cta-button text="Submit an issue" link="https://green-phys.youtrack.cloud/newIssue" icon="bug_report" >}}
+{{< cta-button text="Submit an issue" link="https://github.com/Green-Phys/green-mbpt/issues/new/choose" icon="error" err="yes" >}}
 {{< cta-button text="Discord" link="https://discord.gg/ty9FE6u3mg" icon="forum" >}}
 </div>
 
@@ -93,5 +93,5 @@ cmake -S green-mbpt -B green-mbpt-build \
 
 <div class="btn-grid">
 {{< cta-button text="Installation Guide" link="/docs/installation/" icon="rocket_launch" >}}
-{{< cta-button text="Submit an issue" link="https://green-phys.youtrack.cloud/newIssue" icon="bug_report" >}}
+{{< cta-button text="Submit an issue" link="https://github.com/Green-Phys/green-mbpt/issues/new/choose" icon="error" err="yes" >}}
 </div>


### PR DESCRIPTION
## Summary
- The homepage's "Submit an issue" button links to GitHub issues (`green-mbpt/issues/new/choose`), but several docs pages still pointed to the old YouTrack tracker (`green-phys.youtrack.cloud/newIssue`)
- Replaced every YouTrack issue link across the site with the homepage's GitHub issues link
- Restyled the two "Submit an issue" buttons on the troubleshooting page (`icon="error" err="yes"`) to match the homepage button, since they were standalone buttons rather than inline text links

## Test plan
- [ ] Render the docs site locally and click through the "Submit an issue" buttons/links on the troubleshooting, contribution, and installation pages to confirm they point to GitHub issues